### PR TITLE
prevent directory import error

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,7 @@
 //@ts-ignore
 import type { ComputePositionConfig, ComputePositionReturn, FloatingElement, Middleware, Padding, ReferenceElement, VirtualElement } from "./core/index.js";
 //@ts-ignore
-import { arrow as arrowCore } from "./core";
+import { arrow as arrowCore } from "./core/index.js";
 import { autoUpdate as _autoUpdate, computePosition, type AutoUpdateOptions, type MiddlewareState } from "./dom/index.js";
 import type { Readable, Writable } from "svelte/store";
 import { get } from "svelte/store";


### PR DESCRIPTION
When importing `svelte-floating-ui` from a transitive dependency I receive the following message: 

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '<working_dir>/node_modules/svelte-floating-ui/core' is not supported resolving ES modules imported from <working_dir>/node_modules/svelte-floating-ui/index.js
```

This PR should prevent the error