### PR TITLE
Include SVGElement in types

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -18,9 +18,9 @@ export type ComputeConfig = Partial<ComputePositionConfig> & {
     autoUpdate?: boolean | Partial<AutoUpdateOptions>
 };
 export type UpdatePosition = (contentOptions?: Omit<ComputeConfig, 'autoUpdate'>) => void;
-export type ReferenceAction = (node: HTMLElement | Writable<VirtualElement> | VirtualElement) => void;
-export type ContentAction = (node: HTMLElement, contentOptions?: ComputeConfig) => void;
-export type ArrowOptions = { padding?: Padding, element: Writable<HTMLElement | undefined | null> };
+export type ReferenceAction = (node: HTMLElement | SVGElement | Writable<VirtualElement> | VirtualElement) => void;
+export type ContentAction = (node: HTMLElement | SVGElement, contentOptions?: ComputeConfig) => void;
+export type ArrowOptions = { padding?: Padding, element: Writable<HTMLElement | SVGElement | undefined | null> };
 
 export function createFloatingActions(initOptions?: ComputeConfig): [ReferenceAction, ContentAction, UpdatePosition] {
     let referenceElement: ReferenceElement;


### PR DESCRIPTION
The reference action returned by `createFloatingActions` accepts an `SVGElement` in addition to the currently defined types. I've tested this to work just fine.

I also added `SVGElement` to `ContentAction` and `ArrowOptions`, but did not test those. It feels safe enough, though.